### PR TITLE
Add TrafficPolicy to postfix service

### DIFF
--- a/examples/kubernetes/services/postfix.yaml
+++ b/examples/kubernetes/services/postfix.yaml
@@ -26,5 +26,7 @@ spec:
   - port: 995
     name: pop3s
     targetPort: pop3s
+  externalTrafficPolicy: Local
+  internalTrafficPolicy: Cluster
   externalIPs:
   - "<your-node-ip4-address>"


### PR DESCRIPTION
If "externalTrafficPolicy: Local" is defined, the client source IP address remains the original